### PR TITLE
Introduce ConfigLoader dataclass

### DIFF
--- a/src/analysis/classification.py
+++ b/src/analysis/classification.py
@@ -15,7 +15,7 @@ from sklearn.svm import SVC
 from sklearn.ensemble import RandomForestClassifier
 from preprocessing.processflat import x_features_return
 from umap_run import run_umap
-from preprocessing.loading import load_args_resolved
+from preprocessing.config import ConfigLoader
 
 
 # ---------------------------------------------------------------
@@ -149,8 +149,8 @@ def run_umap_classification(args, classification, paths):
 # Script entry point
 # -----------------------
 def main():
-    # Load args, config, and paths
-    args, config, paths = load_args_resolved()
+    loader = ConfigLoader()
+    args, config, paths = loader.load()
 
     # Extract classification block
     classification = config["classification"]

--- a/src/analysis/clustering.py
+++ b/src/analysis/clustering.py
@@ -10,7 +10,7 @@ from sklearn.cluster import KMeans
 from analysis.umap_run import run_umap
 from preprocessing.processflat import x_features_return
 from analysis.clustering_evaluation import evaluate_kmeans, evaluate_gmm, evaluate_hdbscan, evaluate_consensus
-from preprocessing.loading import load_args_resolved
+from preprocessing.config import ConfigLoader
 import json
 import warnings
 warnings.filterwarnings("ignore")
@@ -182,7 +182,8 @@ def main_clustering(df_masked, df_meta, params):
 
 
 if __name__ == "__main__":
-    args = load_args_resolved()
+    loader = ConfigLoader()
+    args, _, _ = loader.load()
 
     df_masked_raw = pd.read_pickle(args['df_path'])
     df_metadata = pd.read_csv(args['df_meta'])

--- a/src/analysis/regression.py
+++ b/src/analysis/regression.py
@@ -11,8 +11,8 @@ import warnings
 warnings.filterwarnings("ignore")
 import sys
 from analysis.umap_run import run_umap
-from preprocessing.processflat import x_features_return, load_args_resolved
-from preprocessing.loading import load_args_resolved
+from preprocessing.processflat import x_features_return
+from preprocessing.config import ConfigLoader
 from analysis.plotting import plot_ols_diagnostics, plot_actual_vs_predicted
 
 # ------------------------------------------------------------
@@ -183,7 +183,8 @@ def main_regression(df_masked, df_meta, params):
 
 
 if __name__ == "__main__":
-    args = load_args_resolved()
+    loader = ConfigLoader()
+    args, _, _ = loader.load()
 
     # Load configuration and metadata
     df_masked_raw = pd.read_pickle(args['df_path'])

--- a/src/preprocessing/__init__.py
+++ b/src/preprocessing/__init__.py
@@ -1,0 +1,15 @@
+from .config import ConfigLoader
+from .data_loader import (
+    load_fdc_maps,
+    load_metadata,
+    gmm_label_cdr,
+    load_yeo,
+)
+
+__all__ = [
+    "ConfigLoader",
+    "load_fdc_maps",
+    "load_metadata",
+    "gmm_label_cdr",
+    "load_yeo",
+]

--- a/src/preprocessing/config.py
+++ b/src/preprocessing/config.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+import json
+from typing import Dict, Any, Tuple
+
+@dataclass
+class ConfigLoader:
+    config_path: str = "src/parameters/config.json"
+    paths_path: str = "src/parameters/paths.json"
+
+    def load(self) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Dict[str, str]]]:
+        with open(self.config_path) as f:
+            config = json.load(f)
+        with open(self.paths_path) as f:
+            paths = json.load(f)
+
+        args = {}
+        for section in config.values():
+            if isinstance(section, dict):
+                args.update(section)
+
+        flat_paths = {}
+        for section in paths.values():
+            if isinstance(section, dict):
+                flat_paths.update(section)
+
+        args["df_path"] = self.resolve_data_path(
+            dataset_type=args.get("dataset_type", "fdc"),
+            threshold=args.get("threshold"),
+            paths=paths
+        )
+
+        args.update(flat_paths)
+        return args, config, paths
+
+    @staticmethod
+    def resolve_data_path(dataset_type: str, threshold, paths: Dict[str, Any]) -> str:
+        flat_paths = {}
+        for section in paths.values():
+            if isinstance(section, dict):
+                flat_paths.update(section)
+
+        if dataset_type == "fdc":
+            if not threshold:
+                return flat_paths["df_masked"]
+            if threshold == 0.2:
+                return flat_paths["df_masked_02"]
+            raise ValueError(f"No FDC path defined for threshold={threshold}")
+
+        if dataset_type == "networks":
+            if not threshold:
+                return flat_paths["net_noThr"]
+            if threshold == 0.2:
+                return flat_paths["net_thr02"]
+            if threshold == 0.1:
+                return flat_paths["net_thr01"]
+            raise ValueError(f"No network path defined for threshold={threshold}")
+
+        raise ValueError(f"Unknown dataset_type: {dataset_type}")

--- a/src/preprocessing/data_loader.py
+++ b/src/preprocessing/data_loader.py
@@ -1,0 +1,62 @@
+import os
+import glob
+import pandas as pd
+import nibabel as nib
+import numpy as np
+from sklearn.mixture import GaussianMixture
+
+
+def load_fdc_maps(params):
+    dir_fc_maps = params['dir_FCmaps']
+    path_files = sorted(glob.glob(os.path.join(dir_fc_maps, '*gz')))
+    patients_id = [os.path.basename(file).replace('.FDC.nii.gz', '') for file in path_files]
+
+    maps_fdc = []
+    for path in path_files:
+        data = nib.load(path).get_fdata().flatten()
+        maps_fdc.append(data)
+
+    raw_df = pd.DataFrame(maps_fdc)
+    raw_df.insert(0, 'ID', patients_id)
+    raw_df.to_pickle(params['raw_df'])
+    return path_files, patients_id, raw_df
+
+
+def load_metadata(cognitive_dataset):
+    df_meta = pd.read_excel(cognitive_dataset, sheet_name='Sheet1')
+    df_meta['Age'] = df_meta['Age'].round(1)
+    df_meta = df_meta[df_meta['ID'] != '4_S_5003'].reset_index(drop=True)
+    return df_meta
+
+
+def gmm_label_cdr(df_meta):
+    df_cdr = df_meta[['ID', 'CDR_SB']].dropna().copy()
+    np.random.seed(42)
+    x_gmm = df_cdr['CDR_SB'].values.reshape(-1, 1)
+    gmm = GaussianMixture(n_components=3, random_state=42).fit(x_gmm)
+    df_cdr['labels_gmm_cdr'] = gmm.predict(x_gmm)
+
+    means = df_cdr.groupby('labels_gmm_cdr')['CDR_SB'].mean().sort_values()
+    label_map = {old: new for new, old in enumerate(means.index)}
+    df_cdr['labels_gmm_cdr'] = df_cdr['labels_gmm_cdr'].map(label_map)
+
+    label_map = dict(zip(df_cdr['ID'], df_cdr['labels_gmm_cdr']))
+    df_meta = df_meta.drop(columns=['labels_gmm_cdr'], errors='ignore')
+    df_meta['labels_gmm_cdr'] = df_meta['ID'].map(label_map).astype('Int64')
+    return df_meta
+
+
+def load_yeo(params, df_meta):
+    save_dir = params["dir_yeo_df"]
+    mapping = {
+        "yeo_noThr": "networks_noTHR.csv",
+        "yeo_01thr": "networks_thr01.csv",
+        "yeo_02thr": "networks_thr02.csv"
+    }
+    dfs = []
+    for key, out_name in mapping.items():
+        df = pd.read_csv(params[key]).rename(columns={"CODE": "ID"})
+        df = df.set_index("ID").loc[df_meta['ID']].reset_index()
+        df.to_csv(os.path.join(save_dir, out_name), index=False)
+        dfs.append(df)
+    return tuple(dfs)

--- a/test/test_loading.py
+++ b/test/test_loading.py
@@ -3,15 +3,15 @@ import pandas as pd
 import pytest
 import json
 
-from src.data_processing.loading import load_FDCmaps, load_metadata, gmm_label_CDR, load_Yeo
+from preprocessing.data_loader import load_fdc_maps, load_metadata, gmm_label_cdr, load_yeo
 
 # Load config
-with open("/preprocessing/parameters/paths.json", "r") as f:
+with open("src/parameters/paths.json", "r") as f:
     config = json.load(f)
 
 
-def test_load_FDCmaps():
-    files_path, subject_id, raw_df = load_FDCmaps(config)
+def test_load_fdc_maps():
+    files_path, subject_id, raw_df = load_fdc_maps(config)
 
     # Check number of files and subjects
     assert len(files_path) == 176, f"Expected 176 files, got {len(files_path)}"
@@ -50,13 +50,13 @@ def test_load_metadata():
 
 
 
-def test_load_Yeo():
+def test_load_yeo():
     # Load metadata and apply GMM labels
     df_meta = load_metadata(config["cognitive_dataset"])
-    df_meta = gmm_label_CDR(df_meta)
+    df_meta = gmm_label_cdr(df_meta)
 
     # Load Yeo networks
-    df_no_thr, df_thr01, df_thr02 = load_Yeo(config, df_meta)
+    df_no_thr, df_thr01, df_thr02 = load_yeo(config, df_meta)
 
     # Expected shape including ID column
     expected_shape = (176, 9)


### PR DESCRIPTION
## Summary
- refactor config parsing into new `ConfigLoader` dataclass
- move data-loading utilities to `data_loader.py`
- expose loader utilities via `preprocessing` package
- update analysis scripts to use `ConfigLoader`
- adjust tests to new module paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685540dec9c0832ba3d9320ba6e15bee